### PR TITLE
Fixed TD(lambda) update, added T-Maze

### DIFF
--- a/grl/environment/environment.py
+++ b/grl/environment/environment.py
@@ -2,9 +2,10 @@ import numpy as np
 
 from . import examples_lib
 from . import memory_lib
+from . import tmaze_lib
 from .pomdp_file import POMDPFile
 
-def load_spec(name, memory_id=None):
+def load_spec(name, memory_id: int = None, tmaze_corridor_length: int = 5):
     """
     Loads a pre-defined POMDP
     :param name:      the name of the function or .POMDP file defining the POMDP
@@ -14,11 +15,15 @@ def load_spec(name, memory_id=None):
     # Try to load from examples_lib first
     # then from pomdp_files
     spec = None
-    try:
-        spec = getattr(examples_lib, name)()
+    if 'tmaze' in name:
+        spec = getattr(tmaze_lib, name)(tmaze_corridor_length)
+    else:
+        try:
+            spec = getattr(examples_lib, name)()
 
-    except AttributeError as _:
-        pass
+        except AttributeError as _:
+            pass
+
     if spec is None:
         try:
             spec = POMDPFile(name).get_spec()

--- a/grl/environment/examples_lib.py
+++ b/grl/environment/examples_lib.py
@@ -593,6 +593,30 @@ def example_22():
 
     return to_dict(T, R, 0.999, p0, phi, Pi_phi)
 
+
+def simple_chain(n: int = 10):
+    T = np.zeros((n, n))
+    states = np.arange(n)
+    starts = states[:-1]
+    ends = states[1:]
+    T[starts, ends] = 1
+    T[n - 1, n - 1] = 1
+    T = np.expand_dims(T, 0)
+
+    R = np.zeros((n, n))
+    R[-2, -1] = 1
+    R = np.expand_dims(R, 0)
+
+    p0 = np.zeros(n)
+    p0[0] = 1
+
+    phi = np.eye(n)
+
+    Pi_phi = [np.ones((n, 1))]
+
+    return to_dict(T, R, 0.9, p0, phi, Pi_phi)
+
+
 def to_dict(T, R, gamma, p0, phi, Pi_phi, Pi_phi_x=None):
     return {
         'T': T,

--- a/grl/environment/tmaze_lib.py
+++ b/grl/environment/tmaze_lib.py
@@ -1,0 +1,101 @@
+import numpy as np
+from .examples_lib import to_dict
+
+def tmaze(n: int, discount: float = 0.9):
+    """
+    Return T, R, gamma, p0 and phi for tmaze, for a given corridor length n
+    """
+    n_states = 2 * n  # corridors
+    n_states += 2  # start states
+    n_states += 2  # T junctions
+    n_states += 1  # terminal state
+
+    T_up = np.eye(n_states, n_states)
+    T_down = T_up.copy()
+    T_up[[-1, -2, -3], [-1, -2, -3]] = 0
+    T_down[[-1, -2, -3], [-1, -2, -3]] = 0
+
+    # If we go up or down at the junctions, we terminate
+    T_up[[-1 - 1, -2 - 1], [-1, -1]] = 1
+    T_down[[-1 - 1, -2 - 1], [-1, -1]] = 1
+
+    T_left = np.zeros((n_states, n_states))
+    T_right = T_left.copy()
+
+    # At the leftmost and rightmost states we transition to ourselves
+    T_left[[0, 1], [0, 1]] = 1
+    T_right[[-1 - 1, -2 - 1], [-1 -1, -2 - 1]] = 1
+
+    # transition to -2 (left) or +2 (right) index
+    all_nonterminal_idxes = np.arange(n_states - 1)
+    T_left[all_nonterminal_idxes[2:], all_nonterminal_idxes[:-2]] = 1
+    T_right[all_nonterminal_idxes[:-2], all_nonterminal_idxes[2:]] = 1
+
+    T = np.array([T_up, T_right, T_down, T_left])
+
+    # Specify last state as terminal
+    T[:, -1, -1] = 1
+
+    R_left = np.zeros((n_states, n_states))
+    R_right = R_left.copy()
+
+    R_up = R_left.copy()
+    R_down = R_up.copy()
+
+    # If reward is north
+    R_up[-2 - 1, -1] = 4
+    R_down[-2 - 1, -1] = -0.1
+
+    # If reward is south
+    R_up[-1 - 1, -1] = -0.1
+    R_down[-1 - 1, -1] = 4
+
+    R = np.array([R_up, R_right, R_down, R_left])
+
+    # Initialize uniformly at random between north start and south start
+    p0 = np.zeros(n_states)
+    p0[:2] = 0.5
+
+    # Observation function. We have 4 possible obs - start_up, start_down, corridor and junction.
+    # terminal obs doesn't matter.
+    phi = np.zeros((n_states, 4))
+
+    phi[0, 0] = 1
+    phi[1, 1] = 1
+
+    phi[2:2 + n, 2] = 1
+    if n > 0:
+        phi[2 + n, 2] = 1
+
+    phi[-3:, 3] = 1
+
+    return T, R, discount, p0, phi
+
+
+def tmaze_up(n: int, discount: float = 0.9):
+    # n_obs x n_actions
+    Pi_phi = [
+        np.array([
+            [0, 1, 0, 0],
+            [0, 1, 0, 0],
+            [0, 1, 0, 0],
+            [1, 0, 0, 0]
+        ])
+    ]
+    return to_dict(*tmaze(n, discount=discount), Pi_phi)
+
+def tmaze_two_thirds_up(n: int, discount: float = 0.9):
+    # n_obs x n_actions
+    Pi_phi = [
+        np.array([
+            [0, 1, 0, 0],
+            [0, 1, 0, 0],
+            [0, 1, 0, 0],
+            [2/3, 0, 1/3, 0]
+        ])
+    ]
+    return to_dict(*tmaze(n, discount=discount), Pi_phi)
+
+
+
+

--- a/grl/mdp.py
+++ b/grl/mdp.py
@@ -1,7 +1,6 @@
 import copy
-# import gmpy
-import numpy as onp
-import jax.numpy as np
+from gmpy2 import mpz
+import numpy as np
 
 def normalize(M, axis=-1):
     M = M.astype(float)
@@ -63,7 +62,7 @@ def one_hot(x, n):
     return np.eye(n)[x]
 
 class MDP:
-    def __init__(self, T, R, p0, gamma=0.9):
+    def __init__(self, T, R, p0, gamma: float = 0.9):
         self.n_states = len(T[0])
         self.n_obs = self.n_states
         self.n_actions = len(T)
@@ -79,7 +78,7 @@ class MDP:
 
     def get_policy(self, i):
         assert i < self.n_actions**self.n_states
-        pi_string = gmpy.digits(i, self.n_actions).zfill(self.n_states)
+        pi_string = mpz(str(i)).digits(self.n_actions).zfill(self.n_states)
         pi = np.asarray(list(pi_string), dtype=int)
         return pi
 
@@ -106,14 +105,14 @@ class MDP:
 
     def step(self, s, a, gamma):
         pr_next_s = self.T[a, s, :]
-        sp = onp.random.choice(self.n_states, p=pr_next_s)
+        sp = np.random.choice(self.n_states, p=pr_next_s)
         r = self.R[a][s][sp]
         # Check if sp is terminal state
         sp_is_absorbing = (self.T[:, sp, sp] == 1)
         done = sp_is_absorbing.all()
         # Discounting
         # End episode with probability 1-gamma
-        if onp.random.uniform() < (1 - gamma):
+        if np.random.uniform() < (1 - gamma):
             done = True
 
         return sp, r, done
@@ -203,7 +202,7 @@ class AbstractMDP(MDP):
         return base_str + '\n' + repr(self.phi)
 
     def observe(self, s):
-        return onp.random.choice(self.n_obs, p=self.phi[s])
+        return np.random.choice(self.n_obs, p=self.phi[s])
 
     # def B(self, pi, t=200):
     #     p = self.base_mdp.stationary_distribution(pi=pi, p0=self.p0, max_steps=t)
@@ -243,7 +242,7 @@ class AbstractMDP(MDP):
     def generate_random_policies(self, n):
         policies = []
         for _ in range(n):
-            policies.append(onp.random.dirichlet(np.ones(self.n_actions), self.n_obs))
+            policies.append(np.random.dirichlet(np.ones(self.n_actions), self.n_obs))
 
         return policies
 

--- a/grl/memory.py
+++ b/grl/memory.py
@@ -1,7 +1,7 @@
 from .mdp import MDP, AbstractMDP
 
 # import numpy as np
-import jax.numpy as np
+import numpy as np
 from jax.config import config
 
 config.update("jax_enable_x64", True)

--- a/grl/policy_eval.py
+++ b/grl/policy_eval.py
@@ -1,6 +1,6 @@
 import logging
 
-import jax.numpy as np
+import numpy as np
 from jax.config import config
 
 config.update("jax_enable_x64", True)

--- a/grl/run.py
+++ b/grl/run.py
@@ -8,13 +8,13 @@ import jax
 import matplotlib.pyplot as plt
 import seaborn as sns
 
-from .environment import *
-from .mdp import MDP, AbstractMDP
-from .td_lambda import td_lambda
-from .policy_eval import PolicyEval
-from .memory import memory_cross_product
-from .grad import do_grad
-from .utils import pformat_vals, RTOL
+from grl.environment import *
+from grl.mdp import MDP, AbstractMDP
+from grl.td_lambda import td_lambda
+from grl.policy_eval import PolicyEval
+from grl.memory import memory_cross_product
+from grl.grad import do_grad
+from grl.utils import pformat_vals, RTOL
 
 np.set_printoptions(precision=4, suppress=True)
 
@@ -216,6 +216,10 @@ if __name__ == '__main__':
         help='number of rollouts to run')
     parser.add_argument('--log', action='store_true',
         help='save output to logs/')
+
+    parser.add_argument('--tmaze_corridor_length', default=5, type=int,
+                        help='[T-MAZE] length of t-maze corridor')
+
     parser.add_argument('--seed', default=None, type=int,
         help='seed for random number generators')
     parser.add_argument('-f', '--fool-ipython') # hack to allow running in ipython notebooks
@@ -225,12 +229,13 @@ if __name__ == '__main__':
     args = parser.parse_args()
     del args.fool_ipython
 
-    logging.basicConfig(format='%(message)s', level=logging.INFO)
+    logging.basicConfig(format='%(message)s', level=logging.INFO, handlers=[logging.StreamHandler()])
+    logging.getLogger().setLevel(logging.INFO)
     if args.log:
         pathlib.Path('logs').mkdir(exist_ok=True)
         rootLogger = logging.getLogger()
         mem_part = 'no_memory'
-        if args.use_memory > 0:
+        if args.use_memory is not None and args.use_memory > 0:
             mem_part = f'memory_{args.use_memory}'
         name = f'logs/{args.spec}-{mem_part}-{time.time()}.log'
         rootLogger.addHandler(logging.FileHandler(name))
@@ -240,7 +245,7 @@ if __name__ == '__main__':
         jax.random.PRNGKey(args.seed)
 
     # Get POMDP definition
-    spec = environment.load_spec(args.spec, args.use_memory)
+    spec = environment.load_spec(args.spec, memory_id=args.use_memory, tmaze_corridor_length=args.tmaze_corridor_length)
     logging.info(f'spec:\n {args.spec}\n')
     logging.info(f'T:\n {spec["T"]}')
     logging.info(f'R:\n {spec["R"]}')

--- a/grl/td_lambda.py
+++ b/grl/td_lambda.py
@@ -15,15 +15,18 @@ def td_lambda(
     if pi_ground.shape[0] != mdp.n_states:
         raise ValueError("pi must be a valid policy for the ground mdp")
 
+    print(f"Running TD(λ) with λ = {lambda_}")
+
     q = np.zeros((mdp.n_actions, mdp.n_obs))
 
     for i in range(n_episodes):
         z = np.zeros((mdp.n_actions, mdp.n_obs)) # eligibility traces
         s = np.random.choice(mdp.n_states, p=mdp.p0)
+        a = np.random.choice(mdp.n_actions, p=pi_ground[s])
         done = False
         while not done:
-            a = np.random.choice(mdp.n_actions, p=pi_ground[s])
             next_s, r, done = mdp.step(s, a, mdp.gamma)
+            next_a = np.random.choice(mdp.n_actions, p=pi_ground[next_s])
             ob = mdp.observe(s)
             next_ob = mdp.observe(next_s)
 
@@ -40,10 +43,11 @@ def td_lambda(
             z *= lambda_
             z[a, ob] += 1 # Accumulating traces
             # z[a, ob] = 1 # Replacing traces
-            delta = r + mdp.gamma * q[a, next_ob] - q[a, ob]
+            delta = r + mdp.gamma * q[next_a, next_ob] - q[a, ob]
             q += alpha * delta * z
 
             s = next_s
+            a = next_a
 
         if i % (n_episodes / 10) == 0:
             print(f'Sampling episode: {i}/{n_episodes}')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 numpy
-gmpy
+gmpy2
 jax[cpu]
 seaborn
 matplotlib
+-e .

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,8 @@
+from setuptools import find_packages
+from setuptools import setup
+
+setup(
+    name='grl',
+    version='0.1.0',
+    packages=find_packages(),
+)

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from grl.grl import load_spec, do_grad, RTOL
+from grl import load_spec, do_grad, RTOL
 
 def test_example_7_p():
     """

--- a/tests/test_policy_eval.py
+++ b/tests/test_policy_eval.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from grl.grl import PolicyEval, load_spec, MDP, AbstractMDP, memory_cross_product
+from grl import PolicyEval, load_spec, MDP, AbstractMDP, memory_cross_product
 
 def assert_pe_results(spec, answers, use_memory=False):
     mdp = MDP(spec['T'], spec['R'], spec['p0'], spec['gamma'])

--- a/tests/test_td_lambda.py
+++ b/tests/test_td_lambda.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+from grl.mdp import MDP
+from grl import environment
+from grl.td_lambda import td_lambda
+
+
+if __name__ == "__main__":
+    chain_length = 10
+    spec = environment.load_spec('simple_chain', memory_id=None)
+    n_episodes = 10000
+
+    mdp = MDP(spec['T'], spec['R'], spec['p0'], spec['gamma'])
+    policies = spec['Pi_phi']
+
+    ground_truth_vals = spec['gamma'] ** np.arange(chain_length - 2, -1, -1)
+
+    v, q = td_lambda(
+        mdp,
+        policies[0],
+        lambda_=1,
+        alpha=0.01,
+        n_episodes=n_episodes,
+    )
+
+    print(f"Calculated values: {v[:-1]}\n"
+          f"Ground-truth values: {ground_truth_vals}")
+
+    assert np.all(np.isclose(v[:-1], ground_truth_vals, atol=1e-3))
+
+

--- a/tests/test_tmaze.py
+++ b/tests/test_tmaze.py
@@ -1,0 +1,93 @@
+import numpy as np
+
+from grl.mdp import MDP, AbstractMDP
+from grl.environment.tmaze_lib import tmaze
+
+
+if __name__ == "__main__":
+    corridor_length = 0
+    T, R, gamma, p0, phi = tmaze(corridor_length)
+    mdp = MDP(T, R, p0, gamma=gamma)
+    pomdp = AbstractMDP(mdp, phi)
+
+    n_samples = 10000
+
+    # first we test our start states
+    start_counts = np.zeros(2)
+    for _ in range(n_samples):
+        s = np.random.choice(pomdp.n_states, p=pomdp.p0)
+        start_counts[s] += 1
+
+        ob = pomdp.observe(s)
+        if s == 0:
+            assert ob == 0
+        elif s == 1:
+            assert ob == 1
+
+    assert np.all(np.isclose(start_counts / n_samples, np.zeros_like(start_counts) + 0.5, atol=1e-1))
+
+    # Now we test bumping
+    bump_ns_states = np.arange(0, mdp.n_states - 3).astype(int)
+    for s in bump_ns_states:
+        # test up
+        next_s, r, done = pomdp.step(s, 0, 1)
+        assert next_s == s and r == 0 and not done
+
+        # test down
+        next_s, r, done = pomdp.step(s, 2, 1)
+        assert next_s == s and r == 0 and not done
+
+    bump_east_states = np.array([mdp.n_states - 2 - 1, mdp.n_states - 1 - 1])
+    bump_west_states = np.array([0, 1])
+    for s in bump_east_states:
+        next_s, r, done = pomdp.step(s, 1, 1)
+        assert next_s == s and r == 0 and not done
+
+    for s in bump_west_states:
+        next_s, r, done = pomdp.step(s, 3, 1)
+        assert next_s == s and r == 0 and not done
+
+    go_right_states = np.arange(0, mdp.n_states - 3)
+    for s in go_right_states:
+        next_s, r, done = pomdp.step(s, 1, 1)
+        assert next_s == s + 2 and r == 0 and not done
+
+    go_left_states = np.arange(2, mdp.n_states - 1)
+    for s in go_left_states:
+        next_s, r, done = pomdp.step(s, 3, 1)
+        assert next_s == s - 2 and r == 0 and not done
+
+    # make sure our terminals are terminals
+    for i in range(mdp.n_actions):
+        next_s, r, done = pomdp.step(mdp.n_states - 1, 0, 0)
+        assert done and next_s == mdp.n_states - 1 and r == 0
+
+    # Test rewarding transitions
+    top_junction = mdp.n_states - 2 - 1
+    bottom_junction = mdp.n_states - 1 - 1
+
+    # top rewards
+    next_s, r, done = pomdp.step(top_junction, 0, 0)
+    assert done and next_s == mdp.n_states - 1 and r == 4
+
+    next_s, r, done = pomdp.step(top_junction, 2, 0)
+    assert done and next_s == mdp.n_states - 1 and r == -0.1
+
+    # Bottom rewards
+    next_s, r, done = pomdp.step(bottom_junction, 0, 0)
+    assert done and next_s == mdp.n_states - 1 and r == -0.1
+
+    next_s, r, done = pomdp.step(bottom_junction, 2, 0)
+    assert done and next_s == mdp.n_states - 1 and r == 4
+
+    all_0_obs_states = np.array([0])
+    all_1_obs_states = np.array([1])
+    all_2_obs_states = np.arange(2, mdp.n_states - 2 - 1)
+    all_3_obs_states = np.arange(mdp.n_states - 2 - 1, mdp.n_states)
+
+    for i, list_s in enumerate([all_0_obs_states, all_1_obs_states, all_2_obs_states, all_3_obs_states]):
+        for s in list_s:
+            assert pomdp.observe(s) == i
+
+    print("All tests passed for T-maze")
+


### PR DESCRIPTION
Quite a few changes made here!

First is to fix a bug in the TD(lambda) implementation, where the bootstrapped targets were using the same action as the current action. Changed that to the next action.

Second is to add Bakker's T-Maze as an example!

Third, I've turned all the calls to `jax.numpy` back to `numpy` calls (we see a big speed increase from this). If experiments every get unwieldy I can always look into `jit`ting things to speed them up even more. 

Fourthly (idk if that's a word), I've added a small test for the TD(lambda) implementation with the Simple Chain environment.
The Simple Chain environment is a 10-state MDP (with all states connected in a line) with a single action (go right), and a single reward from the last non-terminal state to the terminal state. The agent always initializes in the left-most state, and simply goes towards the terminal state in 9 steps. The ground-truth values that all methods should learn is simple to calculate. I might append onto this PR to also test the analytical solving method.

Lastly, I've added a `setup.py` file and added `-e .` to `requirements.txt`. This installs the `grl` package locally, allowing for edits. This is to also get rid of some of the relative imports in favor of calling something like `grl.environment` etc.

Make sure you run `pip install -e .` if this commit goes through!